### PR TITLE
コードの安全性を見直し

### DIFF
--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/KoinModule.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/KoinModule.kt
@@ -4,13 +4,14 @@ import jp.co.yumemi.android.codecheck.index.IndexViewModel
 import jp.co.yumemi.android.codecheck.infra.SearchGithubReposUseCaseQueryServiceImpl
 import jp.co.yumemi.android.codecheck.show.ShowViewModel
 import jp.co.yumemi.android.codecheck.utils.GithubRepoUiState
+import org.koin.android.ext.koin.androidApplication
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val module = module {
 
     /*** ViewModel ***/
-    viewModel { IndexViewModel(get()) }
+    viewModel { IndexViewModel(androidApplication(), get()) }
     viewModel { (githubRepo: GithubRepoUiState) -> ShowViewModel(githubRepo) }
 
     /*** UseCase ***/

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
@@ -55,14 +55,18 @@ class IndexFragment : Fragment(R.layout.fragment_index) {
             indexViewModel.uiState.collect { indexUiState ->
                 indexUiState.githubRepos.consume(
                     success = { indexEpoxyController.setData(it) },
-                    failure = { Toast.makeText(requireContext(), it.message, Toast.LENGTH_SHORT).show() },
+                    failure = { showErrorMessage(it.message) },
                     loading = {},
                 )
             }
         }
     }
 
-    fun navigateToShow(githubRepo: GithubRepoUiState) {
+    private fun showErrorMessage(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
+    }
+
+    private fun navigateToShow(githubRepo: GithubRepoUiState) {
         val action = IndexFragmentDirections
             .actionRepositoriesFragmentToRepositoryFragment(githubRepo = githubRepo)
         findNavController().navigate(action)

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
@@ -55,7 +55,7 @@ class IndexFragment : Fragment(R.layout.fragment_index) {
             indexViewModel.uiState.collect { indexUiState ->
                 indexUiState.githubRepos.consume(
                     success = { indexEpoxyController.setData(it) },
-                    failure = { showErrorMessage(it.onSearchGithub.message.orEmpty()) },
+                    failure = { showErrorMessage(it.message) },
                     loading = {},
                 )
             }

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexFragment.kt
@@ -55,7 +55,7 @@ class IndexFragment : Fragment(R.layout.fragment_index) {
             indexViewModel.uiState.collect { indexUiState ->
                 indexUiState.githubRepos.consume(
                     success = { indexEpoxyController.setData(it) },
-                    failure = { showErrorMessage(it.message) },
+                    failure = { showErrorMessage(it.onSearchGithub.message.orEmpty()) },
                     loading = {},
                 )
             }

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.codecheck.index
 
+import jp.co.yumemi.android.codecheck.SearchGithubReposUseCaseException
 import jp.co.yumemi.android.codecheck.utils.GithubRepoUiState
 import jp.co.yumemi.android.codecheck.utils.State
 
@@ -12,5 +13,5 @@ data class IndexUiState(
 }
 
 data class IndexErrorUiState(
-    val message: String,
+    val onSearchGithub: SearchGithubReposUseCaseException,
 )

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
@@ -12,6 +12,4 @@ data class IndexUiState(
     ) = this.copy(githubRepos = githubRepos)
 }
 
-data class IndexErrorUiState(
-    val onSearchGithub: SearchGithubReposUseCaseException,
-)
+data class IndexErrorUiState(val message: String)

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexUiState.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.codecheck.index
 
-import jp.co.yumemi.android.codecheck.SearchGithubReposUseCaseException
 import jp.co.yumemi.android.codecheck.utils.GithubRepoUiState
 import jp.co.yumemi.android.codecheck.utils.State
 

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexViewModel.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexViewModel.kt
@@ -36,7 +36,7 @@ class IndexViewModel(
                 .mapBoth(
                     success = { githubRepos -> githubRepos.map { it.toUiState() } },
                     failure = {
-                        when(it) {
+                        when (it) {
                             is SearchGithubReposUseCaseException.ConnectionException ->
                                 IndexErrorUiState(application.getString(R.string.index_message_connection_error))
                         }

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexViewModel.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/index/IndexViewModel.kt
@@ -4,9 +4,9 @@
 package jp.co.yumemi.android.codecheck.index
 
 import android.app.Application
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import jp.co.yumemi.android.codecheck.R
 import jp.co.yumemi.android.codecheck.SearchGithubReposUseCase
 import jp.co.yumemi.android.codecheck.SearchGithubReposUseCaseException
 import jp.co.yumemi.android.codecheck.mapBoth
@@ -37,7 +37,8 @@ class IndexViewModel(
                     success = { githubRepos -> githubRepos.map { it.toUiState() } },
                     failure = {
                         when(it) {
-                            is SearchGithubReposUseCaseException.SystemError -> throw it
+                            is SearchGithubReposUseCaseException.ConnectionException ->
+                                IndexErrorUiState(application.getString(R.string.index_message_connection_error))
                         }
                     }
                 )

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
@@ -52,6 +52,8 @@ class SearchGithubReposUseCaseQueryServiceImpl : SearchGithubReposUseCaseQuerySe
         Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionException(e.message.orEmpty()))
     } catch (e: UnknownHostException) {
         Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionException(e.message.orEmpty()))
+    } catch (e: Exception) {
+        Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.SystemError(e.message.orEmpty(), e))
     }
 }
 

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
@@ -67,21 +67,21 @@ data class GithubRepoSerializable(
 @Serializable
 data class GithubRepoItem(
     @SerialName("full_name") val name: String,
-    @SerialName("owner") val owner: GithubRepoOwner,
-    val language: String = "",
-    @SerialName("stargazers_count") val stargazersCount: Long,
-    @SerialName("watchers_count") val watchersCount: Long,
-    @SerialName("forks_count") val forksCount: Long,
-    @SerialName("open_issues_count") val openIssuesCount: Long,
+    @SerialName("owner") val owner: GithubRepoOwner?,
+    val language: String?,
+    @SerialName("stargazers_count") val stargazersCount: Long?,
+    @SerialName("watchers_count") val watchersCount: Long?,
+    @SerialName("forks_count") val forksCount: Long?,
+    @SerialName("open_issues_count") val openIssuesCount: Long?,
 ) {
     fun toGithubRepo() = GithubRepo(
         name = Name(name),
-        ownerIconUrl = OwnerIconUrl(owner.avatarUrl),
-        language = Language(language),
-        stargazersCount = StargazersCount(stargazersCount),
-        watchersCount = WatchersCount(watchersCount),
-        forksCount = ForksCount(forksCount),
-        openIssuesCount = OpenIssuesCount(openIssuesCount),
+        ownerIconUrl = owner?.avatarUrl?.let { OwnerIconUrl(it) },
+        language = language?.let { Language(it) },
+        stargazersCount = stargazersCount?.let { StargazersCount(it) },
+        watchersCount = watchersCount?.let { WatchersCount(it) },
+        forksCount = forksCount?.let { ForksCount(forksCount) },
+        openIssuesCount = openIssuesCount?.let { OpenIssuesCount(openIssuesCount) },
     )
 }
 

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
@@ -49,9 +49,9 @@ class SearchGithubReposUseCaseQueryServiceImpl : SearchGithubReposUseCaseQuerySe
             .toGithubRepos()
             .let { Maybe.Success(it) }
     } catch (e: HttpRequestTimeoutException) {
-        Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionError(e.message.orEmpty()))
+        Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionException(e.message.orEmpty()))
     } catch (e: UnknownHostException) {
-        Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionError(e.message.orEmpty()))
+        Maybe.Failure(SearchGithubReposUseCaseQueryServiceException.ConnectionException(e.message.orEmpty()))
     }
 }
 

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/infra/SearchGithubReposUseCaseQueryServiceImpl.kt
@@ -39,7 +39,7 @@ class SearchGithubReposUseCaseQueryServiceImpl : SearchGithubReposUseCaseQuerySe
                 )
             }
             install(HttpTimeout) {
-                requestTimeoutMillis = 1000
+                requestTimeoutMillis = 2000
             }
         }
         client.get<GithubRepoSerializable>("https://api.github.com/search/repositories") {

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/show/ShowFragment.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/show/ShowFragment.kt
@@ -25,21 +25,47 @@ class ShowFragment : Fragment(R.layout.fragment_show) {
     private val githubRepo: GithubRepoUiState by lazy { args.githubRepo }
     private val showViewModel: ShowViewModel by viewModel { parametersOf(githubRepo) }
 
+    private lateinit var binding: FragmentShowBinding
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentShowBinding.bind(view)
+        binding = FragmentShowBinding.bind(view)
 
         launchInLifecycleScope(Lifecycle.State.STARTED) {
-            showViewModel.uiState.collect {
-                it.githubRepoUiState.consume(
-                    success = { githubRepo ->
-                        binding.githubRepo = githubRepo
-                        binding.showOwnerIconView.load(githubRepo.ownerIconUrl)
-                    }
+            showViewModel.uiState.collect { showUiState ->
+                showUiState.githubRepoUiState.consume(
+                    success = { githubRepo -> setGithubRepo(githubRepo) }
                 )
             }
         }
         Log.d("検索した日時", Date(System.currentTimeMillis()).toString())
+    }
+
+    private fun setGithubRepo(githubRepo: GithubRepoUiState) {
+        binding.apply {
+            showOwnerIconView.load(githubRepo.ownerIconUrl)
+
+            showNameView.text = githubRepo.name
+
+            showLanguageView.text = githubRepo.language
+                ?: getString(R.string.show_language_not_found)
+
+            showStarsView.text = githubRepo.stargazersCount
+                ?.let { getString(R.string.show_stars_view_text, it) }
+                ?: getString(R.string.show_stars_view_text_not_found)
+
+            showWatchersView.text = githubRepo.watchersCount
+                ?.let { getString(R.string.show_watchers_view_text, it) }
+                ?: getString(R.string.show_watchers_view_text_not_found)
+
+            showForksView.text = githubRepo.forksCount
+                ?.let { getString(R.string.show_forks_view_text, it) }
+                ?: getString(R.string.show_watchers_view_text_not_found)
+
+            showOpenIssuesView.text = githubRepo.openIssuesCount
+                ?.let { getString(R.string.show_open_issues_view_text, it) }
+                ?: getString(R.string.show_open_issues_view_text_not_found)
+        }
     }
 }

--- a/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/utils/GithubRepoUiState.kt
+++ b/android/app/src/main/kotlin/jp/co/yumemi/android/codecheck/utils/GithubRepoUiState.kt
@@ -7,12 +7,12 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class GithubRepoUiState(
     val name: String,
-    val ownerIconUrl: String,
-    val language: String,
-    val stargazersCount: String,
-    val watchersCount: String,
-    val forksCount: String,
-    val openIssuesCount: String,
+    val ownerIconUrl: String?,
+    val language: String?,
+    val stargazersCount: String?,
+    val watchersCount: String?,
+    val forksCount: String?,
+    val openIssuesCount: String?,
 ) : Parcelable {
     companion object {
         fun GithubRepoUseCaseModel.toUiState() = GithubRepoUiState(

--- a/android/app/src/main/res/layout/fragment_show.xml
+++ b/android/app/src/main/res/layout/fragment_show.xml
@@ -1,123 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <data>
-        <variable
-            name="githubRepo"
-            type="jp.co.yumemi.android.codecheck.utils.GithubRepoUiState" />
-    </data>
+    <ImageView
+        android:id="@+id/show_owner_icon_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_margin="16dp"
+        android:contentDescription="@null"
+        tools:src="@drawable/jetbrains"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="240dp" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <TextView
+        android:id="@+id/show_name_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        tools:text="JetBrains/kotlin"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/show_owner_icon_view" />
 
-        <ImageView
-            android:id="@+id/show_owner_icon_view"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_margin="16dp"
-            android:contentDescription="@null"
-            tools:src="@drawable/jetbrains"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintWidth_max="240dp" />
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/show_center_guide"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
 
-        <TextView
-            android:id="@+id/show_name_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@{githubRepo.name}"
-            tools:text="JetBrains/kotlin"
-            android:textColor="@color/black"
-            android:textSize="18sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/show_owner_icon_view" />
+    <TextView
+        android:id="@+id/show_language_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        tools:text="Written in Kotlin"
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@id/show_name_view"
+        tools:ignore="MissingConstraints" />
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/show_center_guide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintGuide_percent="0.5" />
+    <TextView
+        android:id="@+id/show_stars_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        tools:text="38530 stars"
+        android:textAlignment="textEnd"
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/show_center_guide"
+        app:layout_constraintTop_toBottomOf="@id/show_name_view" />
 
-        <TextView
-            android:id="@+id/show_language_view"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@{githubRepo.language}"
-            tools:text="Written in Kotlin"
-            android:textColor="@color/black"
-            android:textSize="14sp"
-            app:layout_constraintTop_toBottomOf="@id/show_name_view"
-            tools:ignore="MissingConstraints" />
+    <TextView
+        android:id="@+id/show_watchers_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        tools:text="38530 watchers"
+        android:textAlignment="textEnd"
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/show_center_guide"
+        app:layout_constraintTop_toBottomOf="@id/show_stars_view" />
 
-        <TextView
-            android:id="@+id/show_stars_view"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@{@string/show_stars_view_text(githubRepo.stargazersCount)}"
-            tools:text="38530 stars"
-            android:textAlignment="textEnd"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/show_center_guide"
-            app:layout_constraintTop_toBottomOf="@id/show_name_view" />
+    <TextView
+        android:id="@+id/show_forks_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        tools:text="4675 forks"
+        android:textAlignment="textEnd"
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintLeft_toLeftOf="@id/show_center_guide"
+        app:layout_constraintTop_toBottomOf="@id/show_watchers_view" />
 
-        <TextView
-            android:id="@+id/show_watchers_view"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@{@string/show_watchers_view_text(githubRepo.watchersCount)}"
-            tools:text="38530 watchers"
-            android:textAlignment="textEnd"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/show_center_guide"
-            app:layout_constraintTop_toBottomOf="@id/show_stars_view" />
+    <TextView
+        android:id="@+id/show_open_issues_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        tools:text="131 open issues"
+        android:textAlignment="textEnd"
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/show_center_guide"
+        app:layout_constraintTop_toBottomOf="@id/show_forks_view" />
 
-        <TextView
-            android:id="@+id/show_forks_view"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@{@string/show_forks_view_text(githubRepo.forksCount)}"
-            tools:text="4675 forks"
-            android:textAlignment="textEnd"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintLeft_toLeftOf="@id/show_center_guide"
-            app:layout_constraintTop_toBottomOf="@id/show_watchers_view" />
-
-        <TextView
-            android:id="@+id/show_open_issues_view"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@{@string/show_open_issues_view_text(githubRepo.openIssuesCount)}"
-            tools:text="131 open issues"
-            android:textAlignment="textEnd"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/show_center_guide"
-            app:layout_constraintTop_toBottomOf="@id/show_forks_view" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,8 +5,13 @@
 
     <string name="index_message_connection_error">ネットワークの接続状況を確認してください</string>
 
+    <string name="show_language_not_found">Language Not Found</string>
     <string name="show_stars_view_text">%s stars</string>
+    <string name="show_stars_view_text_not_found">Stars Not Found</string>
     <string name="show_watchers_view_text">%s watchers</string>
+    <string name="show_watchers_view_text_not_found">Watchers Not Found</string>
     <string name="show_forks_view_text">%s forks</string>
+    <string name="show_forks_view_text_not_found">Forks Not Found</string>
     <string name="show_open_issues_view_text">%s open issues</string>
+    <string name="show_open_issues_view_text_not_found">Open Issues Not Found</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="index_search_input_text_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
 
+    <string name="index_message_connection_error">ネットワークの接続状況を確認してください</string>
+
     <string name="show_stars_view_text">%s stars</string>
     <string name="show_watchers_view_text">%s watchers</string>
     <string name="show_forks_view_text">%s forks</string>

--- a/core/domain/src/main/kotlin/jp/co/yumemi/android/codecheck/GithubRepo.kt
+++ b/core/domain/src/main/kotlin/jp/co/yumemi/android/codecheck/GithubRepo.kt
@@ -2,12 +2,12 @@ package jp.co.yumemi.android.codecheck
 
 data class GithubRepo(
     val name: Name,
-    val ownerIconUrl: OwnerIconUrl,
-    val language: Language,
-    val stargazersCount: StargazersCount,
-    val watchersCount: WatchersCount,
-    val forksCount: ForksCount,
-    val openIssuesCount: OpenIssuesCount,
+    val ownerIconUrl: OwnerIconUrl?,
+    val language: Language?,
+    val stargazersCount: StargazersCount?,
+    val watchersCount: WatchersCount?,
+    val forksCount: ForksCount?,
+    val openIssuesCount: OpenIssuesCount?,
 )
 
 @JvmInline

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/GithubRepoUseCaseModel.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/GithubRepoUseCaseModel.kt
@@ -2,20 +2,20 @@ package jp.co.yumemi.android.codecheck
 
 data class GithubRepoUseCaseModel(
     val name: String,
-    val ownerIconUrl: String,
-    val language: String,
-    val stargazersCount: Long,
-    val watchersCount: Long,
-    val forksCount: Long,
-    val openIssuesCount: Long,
+    val ownerIconUrl: String?,
+    val language: String?,
+    val stargazersCount: Long?,
+    val watchersCount: Long?,
+    val forksCount: Long?,
+    val openIssuesCount: Long?,
 )
 
 fun GithubRepo.toUseCaseModel() = GithubRepoUseCaseModel(
     name = name.value,
-    ownerIconUrl = ownerIconUrl.value,
-    language = language.value,
-    stargazersCount = stargazersCount.value,
-    watchersCount = watchersCount.value,
-    forksCount = forksCount.value,
-    openIssuesCount = openIssuesCount.value,
+    ownerIconUrl = ownerIconUrl?.value,
+    language = language?.value,
+    stargazersCount = stargazersCount?.value,
+    watchersCount = watchersCount?.value,
+    forksCount = forksCount?.value,
+    openIssuesCount = openIssuesCount?.value,
 )

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCase.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCase.kt
@@ -10,8 +10,4 @@ sealed class SearchGithubReposUseCaseException : Exception() {
     class ConnectionException(
         override val message: String,
     ) : SearchGithubReposUseCaseException()
-    class SystemError(
-        override val message: String,
-        override val cause: Throwable,
-    ) : SearchGithubReposUseCaseException()
 }

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCase.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCase.kt
@@ -7,6 +7,9 @@ interface SearchGithubReposUseCase {
 }
 
 sealed class SearchGithubReposUseCaseException : Exception() {
+    class ConnectionException(
+        override val message: String,
+    ) : SearchGithubReposUseCaseException()
     class SystemError(
         override val message: String,
         override val cause: Throwable,

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseImpl.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseImpl.kt
@@ -17,9 +17,6 @@ class SearchGithubReposUseCaseImpl(
         is SearchGithubReposUseCaseQueryServiceException.ConnectionException ->
             SearchGithubReposUseCaseException.ConnectionException(message = this.message)
         is SearchGithubReposUseCaseQueryServiceException.SystemError ->
-            SearchGithubReposUseCaseException.SystemError(
-                message = this.message,
-                cause = this.cause,
-            )
+            throw this
     }
 }

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseImpl.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseImpl.kt
@@ -14,10 +14,12 @@ class SearchGithubReposUseCaseImpl(
             )
 
     private fun SearchGithubReposUseCaseQueryServiceException.toSearchGithubReposUseCaseException() = when (this) {
-        is SearchGithubReposUseCaseQueryServiceException.ConnectionError ->
+        is SearchGithubReposUseCaseQueryServiceException.ConnectionException ->
+            SearchGithubReposUseCaseException.ConnectionException(message = this.message)
+        is SearchGithubReposUseCaseQueryServiceException.SystemError ->
             SearchGithubReposUseCaseException.SystemError(
                 message = this.message,
-                cause = this,
+                cause = this.cause,
             )
     }
 }

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseQueryService.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseQueryService.kt
@@ -5,5 +5,9 @@ interface SearchGithubReposUseCaseQueryService {
 }
 
 sealed class SearchGithubReposUseCaseQueryServiceException : Exception() {
-    class ConnectionError(override val message: String) : SearchGithubReposUseCaseQueryServiceException()
+    class ConnectionException(override val message: String) : SearchGithubReposUseCaseQueryServiceException()
+    class SystemError(
+        override val message: String,
+        override val cause: Throwable,
+    ): SearchGithubReposUseCaseQueryServiceException()
 }

--- a/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseQueryService.kt
+++ b/core/usecase/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchGithubReposUseCaseQueryService.kt
@@ -9,5 +9,5 @@ sealed class SearchGithubReposUseCaseQueryServiceException : Exception() {
     class SystemError(
         override val message: String,
         override val cause: Throwable,
-    ): SearchGithubReposUseCaseQueryServiceException()
+    ) : SearchGithubReposUseCaseQueryServiceException()
 }


### PR DESCRIPTION
GithubのAPIページにはどの値がNullになるか分からないためName以外はNullableにして、確実に網羅できるようにした
また、全てのエラーをキャッチしていたところを特定のエラーのみ取るようにして、その上適切なメッセージを出せるように変更